### PR TITLE
Remove defined credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This can be used alongside other plugins such as [@hicksy/arc-plugin-sandbox-str
 
 - Docker installed and running on your system.
 - Node.js (if this project is built as a Node.js tool).
+- A credential file as defined at https://arc.codes/docs/en/guides/developer-experience/create-aws-credentials
+  - Note: Any credentials will be accepted for local development, something just needs to be present, or there will be errors from the sandbox functions that try to populate the database.
 
 ## Usage
 
@@ -19,21 +21,21 @@ This can be used alongside other plugins such as [@hicksy/arc-plugin-sandbox-str
 npm install -D @nasa-gcn/architect-plugin-dynamodb-local
 ```
 
-1. In your `.env` add the following:
+2. In your `.env` add the following:
 
 ```
 ARC_TABLES_PORT=8000
 ARC_DB_EXTERNAL=true
 ```
 
-1. Add the following to your project's `app.arc` configuration file:
+3. Add the following to your project's `app.arc` configuration file:
 
 ```
 @plugins
 nasa-gcn/architect-plugin-dynamodb-local
 ```
 
-1. Seeding the database (optional):
+4. Seeding the database (optional):
 
 ```
 @architect-plugin-dynamodb-local

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This can be used alongside other plugins such as [@hicksy/arc-plugin-sandbox-str
 - Docker installed and running on your system.
 - Node.js (if this project is built as a Node.js tool).
 - A credential file as defined at https://arc.codes/docs/en/guides/developer-experience/create-aws-credentials
-  - Note: Any credentials will be accepted for local development, something just needs to be present, or there will be errors from the sandbox functions that try to populate the database.
+  - Note: Any credentials will be accepted for local development something just needs to be present, or there will be errors from the sandbox functions that try to populate the database.
 
 ## Usage
 

--- a/index.ts
+++ b/index.ts
@@ -49,11 +49,7 @@ export const sandbox = {
         requestTimeout: 10_000,
         httpsAgent: { maxSockets: 500 }, // Increased from default to allow for higher throughput
       },
-      credentials: {
-        // Any credentials can be provided for local
-        accessKeyId: 'local-db',
-        secretAccessKey: 'random-any-string',
-      },
+      credentials,
     })
     const seedFile = arc['architect-plugin-dynamodb-local'].find(
       (item: string[]) => item[0] == 'seedFile'

--- a/index.ts
+++ b/index.ts
@@ -20,12 +20,6 @@ import { dedent } from 'ts-dedent'
 
 let local: Awaited<ReturnType<typeof launch>>
 
-export const credentials = {
-  // Any credentials can be provided for local
-  accessKeyId: 'local-db',
-  secretAccessKey: 'random-any-string',
-}
-
 export const deploy = {
   async services() {
     if (process.env.ARC_DB_EXTERNAL) local = await launch()
@@ -49,7 +43,6 @@ export const sandbox = {
         requestTimeout: 10_000,
         httpsAgent: { maxSockets: 500 }, // Increased from default to allow for higher throughput
       },
-      credentials,
     })
     const seedFile = arc['architect-plugin-dynamodb-local'].find(
       (item: string[]) => item[0] == 'seedFile'

--- a/index.ts
+++ b/index.ts
@@ -49,7 +49,11 @@ export const sandbox = {
         requestTimeout: 10_000,
         httpsAgent: { maxSockets: 500 }, // Increased from default to allow for higher throughput
       },
-      credentials,
+      credentials: {
+        // Any credentials can be provided for local
+        accessKeyId: 'local-db',
+        secretAccessKey: 'random-any-string',
+      },
     })
     const seedFile = arc['architect-plugin-dynamodb-local'].find(
       (item: string[]) => item[0] == 'seedFile'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "architect-plugin-dynamodb-local",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "architect-plugin-dynamodb-local",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@architect/functions": "^8.1.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-gcn/architect-plugin-dynamodb-local",
   "description": "Architect plugin for a local dynamodb instance",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "github:nasa-gcn/architect-plugin-dynamodb-local"

--- a/run.ts
+++ b/run.ts
@@ -45,7 +45,8 @@ export async function launch() {
         const ddbPing = await ddbClient.send(new ListTablesCommand({}))
         if (ddbPing.TableNames) dynamodbReady = true
       } catch (e) {
-        console.log(e, ', table connection not ready, trying again')
+        if (e instanceof Error)
+          console.log(e.name, ', table connection not ready, trying again')
         await new Promise((f) => setTimeout(f, 1000))
       }
     }

--- a/run.ts
+++ b/run.ts
@@ -10,7 +10,6 @@ import waitPort from 'wait-port'
 import { UnexpectedResolveError } from './promises.js'
 import { launchDocker, removeContainer } from './runDocker.js'
 import { DynamoDBClient, ListTablesCommand } from '@aws-sdk/client-dynamodb'
-import { credentials } from './index'
 
 export type LauncherFunction<T = object> = (
   props: T & {
@@ -40,7 +39,6 @@ export async function launch() {
     let dynamodbReady = false
     const ddbClient = new DynamoDBClient({
       endpoint: url,
-      credentials,
     })
     while (!dynamodbReady) {
       try {

--- a/run.ts
+++ b/run.ts
@@ -10,7 +10,6 @@ import waitPort from 'wait-port'
 import { UnexpectedResolveError } from './promises.js'
 import { launchDocker, removeContainer } from './runDocker.js'
 import { DynamoDBClient, ListTablesCommand } from '@aws-sdk/client-dynamodb'
-import { credentials } from './index'
 
 export type LauncherFunction<T = object> = (
   props: T & {
@@ -40,7 +39,11 @@ export async function launch() {
     let dynamodbReady = false
     const ddbClient = new DynamoDBClient({
       endpoint: url,
-      credentials,
+      credentials: {
+        // Any credentials can be provided for local
+        accessKeyId: 'local-db',
+        secretAccessKey: 'random-any-string',
+      },
     })
     while (!dynamodbReady) {
       try {

--- a/run.ts
+++ b/run.ts
@@ -10,6 +10,7 @@ import waitPort from 'wait-port'
 import { UnexpectedResolveError } from './promises.js'
 import { launchDocker, removeContainer } from './runDocker.js'
 import { DynamoDBClient, ListTablesCommand } from '@aws-sdk/client-dynamodb'
+import { credentials } from './index'
 
 export type LauncherFunction<T = object> = (
   props: T & {
@@ -39,11 +40,7 @@ export async function launch() {
     let dynamodbReady = false
     const ddbClient = new DynamoDBClient({
       endpoint: url,
-      credentials: {
-        // Any credentials can be provided for local
-        accessKeyId: 'local-db',
-        secretAccessKey: 'random-any-string',
-      },
+      credentials,
     })
     while (!dynamodbReady) {
       try {

--- a/runDocker.ts
+++ b/runDocker.ts
@@ -12,7 +12,6 @@ import { LauncherFunction } from './run.js'
 
 const [, , command, jsonifiedArgs] = process.argv
 const docker = new Dockerode({ protocol: 'http' })
-const imageName = 'amazon/dynamodb-local:latest'
 
 let containerId = ''
 if (command === 'launch-ddb-local-docker-subprocess') {
@@ -79,25 +78,9 @@ export async function removeContainer(containerId: string) {
   await docker.getContainer(containerId).remove()
 }
 
-async function pullImage(imageName: string) {
-  try {
-    const pullStream = await docker.pull(imageName)
-    pullStream.pipe(process.stdout)
-    await new Promise((resolve, reject) => {
-      pullStream.on('end', resolve)
-      pullStream.on('error', reject)
-    })
-    console.log(`Image ${imageName} pulled successfully`)
-  } catch (error) {
-    console.error(`Error pulling image ${imageName}:`, error)
-  }
-}
-
 async function createDdbContainer(port: number) {
-  await pullImage(imageName)
-
   return await docker.createContainer({
-    Image: imageName,
+    Image: 'amazon/dynamodb-local:latest',
     name: 'dynamodb-local',
     Cmd: ['-jar', 'DynamoDBLocal.jar', '-sharedDb', '-dbPath', '/tmp/'],
     ExposedPorts: {


### PR DESCRIPTION
These credentials would be fine, but the keyId and secret need to be defined anyway for other sandbox functions to work. There is no point in defining them here and in `~/.aws/credentials`, since they will just get used anyway 