### PR TITLE
Only use valid characters in AWS credentials

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,8 +22,8 @@ let local: Awaited<ReturnType<typeof launch>>
 
 export const credentials = {
   // Any credentials can be provided for local
-  accessKeyId: 'local-db',
-  secretAccessKey: 'random-any-string',
+  accessKeyId: 'localDb',
+  secretAccessKey: 'randomAnyString',
 }
 
 export const deploy = {


### PR DESCRIPTION
According to https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html, AWS_ACCESS_KEY_ID can only contain letters and numbers. Underscores and dashes are not allowed.