### PR TITLE
Configure TSC to emit no code, only perform type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "module": "ESNext",
     "moduleResolution": "node",
+    "noEmit": true,
     "esModuleInterop": true,
     "strict": true,
     "types": ["@types/node"]


### PR DESCRIPTION
We use esbuild to level down TypeScript to JavaScript. TSC is only used for type checking.