### PR TITLE
Fix some issues with Docker launching code

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import _arcFunctions from '@architect/functions'
 import { updater } from '@architect/utils'
 import {
   DescribeTableCommand,
-  DynamoDBClient,
+  type DynamoDBClient,
   UpdateTableCommand,
 } from '@aws-sdk/client-dynamodb'
 import {
@@ -81,17 +81,7 @@ export const sandbox = {
       return
     }
 
-    const dynamodbClient = DynamoDBDocumentClient.from(
-      new DynamoDBClient({
-        region: inv.aws.region,
-        endpoint: local.url,
-        requestHandler: {
-          requestTimeout: 10_000,
-          httpsAgent: { maxSockets: 500 }, // Increased from default to allow for higher throughput
-        },
-        credentials,
-      })
-    )
+    const dynamodbClient = DynamoDBDocumentClient.from(local.client)
     const seedFile = arc['architect-plugin-dynamodb-local']?.find(
       (item: string[]) => item[0] == 'seedFile'
     )[1]
@@ -102,8 +92,8 @@ export const sandbox = {
     if (tableStreams?.length) {
       const ddbStreamsClient = new DynamoDBStreamsClient({
         region: inv.aws.region,
-        endpoint: local.url,
-        credentials,
+        endpoint: local.client.config.endpoint,
+        credentials: local.client.config.credentials,
       })
       // Init table streams for those defined
       await Promise.all(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "@aws-sdk/lib-dynamodb": "^3.731.1",
         "@nasa-gcn/architect-plugin-utils": "^0.3.0",
         "lodash": "^4.17.21",
-        "ts-dedent": "^2.2.0",
-        "wait-port": "^1.0.4"
+        "ts-dedent": "^2.2.0"
       },
       "devDependencies": {
         "@architect/architect": "^11.2.2",
@@ -11595,32 +11594,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/wait-port": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
-      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "commander": "^9.3.0",
-        "debug": "^4.3.4"
-      },
-      "bin": {
-        "wait-port": "bin/wait-port.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/wait-port/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "@aws-sdk/lib-dynamodb": "^3.731.1",
     "@nasa-gcn/architect-plugin-utils": "^0.3.0",
     "lodash": "^4.17.21",
-    "ts-dedent": "^2.2.0",
-    "wait-port": "^1.0.4"
+    "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
     "@architect/architect": "^11.2.2",


### PR DESCRIPTION
- Fix tight loop without any sleeps if ListTables returns an HTTP 200 OK response but that does not contain the TableNames response value.
- Remove unused `port` return value.
- Add error message if the Docker container exits prematurely during startup.
- Remove duplicated code to set up DynamoDB client.