### PR TITLE
Rewrite DynamoDB Table streams iteration to fix several issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@aws-sdk/lib-dynamodb": "^3.699.0",
         "@nasa-gcn/architect-plugin-utils": "^0.4.0",
         "lodash": "^4.17.21",
+        "tiny-invariant": "^1.3.3",
         "ts-dedent": "^2.2.0"
       },
       "devDependencies": {
@@ -24,7 +25,7 @@
         "@aws-sdk/util-dynamodb": "^3.699.0",
         "@nasa-gcn/eslint-config-gitignore": "^0.0.2",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-        "@tsconfig/node20": "^20.1.5",
+        "@tsconfig/node22": "^22.0.1",
         "@types/architect__utils": "^4.0.0",
         "@types/aws-lambda": "^8.10.147",
         "@types/lodash": "^4.17.15",
@@ -41,7 +42,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@architect/architect": {
@@ -3276,10 +3277,10 @@
         }
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
-      "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.1.tgz",
+      "integrity": "sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9511,6 +9512,12 @@
       "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
       "integrity": "sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node --test"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@architect/utils": "^4.0.6",
@@ -34,6 +34,7 @@
     "@aws-sdk/lib-dynamodb": "^3.699.0",
     "@nasa-gcn/architect-plugin-utils": "^0.4.0",
     "lodash": "^4.17.21",
+    "tiny-invariant": "^1.3.3",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
@@ -42,7 +43,7 @@
     "@aws-sdk/util-dynamodb": "^3.699.0",
     "@nasa-gcn/eslint-config-gitignore": "^0.0.2",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-    "@tsconfig/node20": "^20.1.5",
+    "@tsconfig/node22": "^22.0.1",
     "@types/architect__utils": "^4.0.0",
     "@types/aws-lambda": "^8.10.147",
     "@types/lodash": "^4.17.15",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "incremental": true,
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "lib": ["ES2024"],
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
- Don't crash if invoking the Lambda fails.
- Iterate over shards in chronological order. Previously, we were iterating over them in _reverse_ chronological order because we were treating the list of shards as a stack (last-in, first-out).
- Fully consume each shard before moving on to the next one.
- Fetch new shards once they are all exhausted.
- Rewrite as an async generator. This simplifies the bookkeeping by eliminating global variables and it makes the code much more linear.