### PR TITLE
Env overwrite fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -180,9 +180,9 @@ export const sandbox = {
 export const set = {
   env() {
     const credsPath = join(homedir(), '.aws', 'credentials')
-    if (isSandbox() && !existsSync(credsPath)) {
+    if (isSandbox() && !existsSync(credsPath))
       return { AWS_ACCESS_KEY_ID: 'dummy', AWS_SECRET_ACCESS_KEY: 'dummy' }
-    } else return {}
+    else return {}
   },
 }
 

--- a/index.ts
+++ b/index.ts
@@ -28,7 +28,10 @@ import {
 import { NativeAttributeValue } from '@aws-sdk/util-dynamodb'
 import { periodically } from '@nasa-gcn/architect-plugin-utils'
 import chunk from 'lodash/chunk.js'
+import { existsSync } from 'node:fs'
 import { access, constants, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import invariant from 'tiny-invariant'
 import { dedent } from 'ts-dedent'
 
@@ -176,9 +179,10 @@ export const sandbox = {
 // in sandbox mode.
 export const set = {
   env() {
-    if (isSandbox())
+    const credsPath = join(homedir(), '.aws', 'credentials')
+    if (isSandbox() && !existsSync(credsPath)) {
       return { AWS_ACCESS_KEY_ID: 'dummy', AWS_SECRET_ACCESS_KEY: 'dummy' }
-    else return {}
+    } else return {}
   },
 }
 


### PR DESCRIPTION
@lpsinger this fixes an issue I was seeing where cognito was throwing errors when trying to interact with anything. The "dummy" values were overwriting short term access keys, making it impossible to actually hit AWS.

The credentials will be loaded automatically as expected if present